### PR TITLE
Updated graphics for monkey and ground tileset

### DIFF
--- a/graphics/sprites/monkey_16x16_neutral_one.png
+++ b/graphics/sprites/monkey_16x16_neutral_one.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:771a17d6c183d30fec5d14f158c56278806cd19d81991112edf74c4dc4e03f28
+size 399

--- a/graphics/spritesheet/floor_16x16_basic_tileset.png
+++ b/graphics/spritesheet/floor_16x16_basic_tileset.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c11a9f03642bccb9b0dcb347b3e431abacadc3443daf1f2b4e0540844861b9f3
+size 649

--- a/graphics/spritesheet/monkey_base_spritesheet.png.import
+++ b/graphics/spritesheet/monkey_base_spritesheet.png.import
@@ -2,7 +2,7 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://b20kouk4ipay0"
+uid="uid://ci8juhrwv13sj"
 path="res://.godot/imported/monkey_base_spritesheet.png-d6257ef5d1aa8a1c293e2304529883f8.ctex"
 metadata={
 "vram_texture": false


### PR DESCRIPTION
`monkey_16x16_neutral_one`
![monkey_16x16_neutral_one](https://github.com/Penguinmaster800/Lotus-Monkey-Jam/assets/54048656/ce2d5bfa-50c1-4af2-a931-f36953abbc20)

`floor_16x16_basic_tileset`
![floor_16x16_basic_tileset](https://github.com/Penguinmaster800/Lotus-Monkey-Jam/assets/54048656/fff17842-f66c-4c3f-94af-853fe0734a5d)
